### PR TITLE
feat(feature-flags): add environment validation

### DIFF
--- a/packages/feature-flags/src/core/FeatureFlagEngine.ts
+++ b/packages/feature-flags/src/core/FeatureFlagEngine.ts
@@ -38,7 +38,10 @@ export interface FlagDefinition {
   rolloutState: RolloutState;
   description: string;
   owner: string;
-  
+
+  // Environment targeting
+  environment?: 'all' | 'development' | 'staging' | 'production';
+
   // Targeting rules
   enabledForRoles?: string[];
   enabledForUsers?: string[];
@@ -154,6 +157,17 @@ export class FeatureFlagEngine {
         enabled: false,
         value: flag.defaultValue,
         reason: 'flag_expired',
+        flagKey
+      };
+    }
+
+    // Check environment
+    const flagEnv = flag.environment ?? 'all';
+    if (flagEnv !== 'all' && flagEnv !== context.environment) {
+      return {
+        enabled: false,
+        value: flag.defaultValue,
+        reason: 'environment_mismatch',
         flagKey
       };
     }


### PR DESCRIPTION
## Summary
- allow flags to specify valid environment
- disable flag when flag.environment mismatches context

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6899f01def788326a3cda0f9b553ceb6