### PR TITLE
Fetch notification settings from API in settings page

### DIFF
--- a/makrx-store-frontend/src/app/account/notifications/page.tsx
+++ b/makrx-store-frontend/src/app/account/notifications/page.tsx
@@ -43,10 +43,8 @@ function NotificationSettingsPage() {
 
   const loadSettings = async () => {
     try {
-      // TODO: Implement getNotificationSettings API method
-      // const userSettings = await api.getNotificationSettings();
-      // setSettings(userSettings);
-      setSettings(settings); // Use default settings for now
+      const userSettings = await api.getNotificationSettings();
+      setSettings(userSettings);
     } catch (error) {
       console.error("Failed to load notification settings:", error);
     } finally {


### PR DESCRIPTION
## Summary
- load notification preferences via `api.getNotificationSettings`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a310d8e948326b037077a169f8f5b