### PR TITLE
feat: add project engagement models and endpoints

### DIFF
--- a/frontend/makrcave-frontend/components/showcase/ProjectShowcaseCard.tsx
+++ b/frontend/makrcave-frontend/components/showcase/ProjectShowcaseCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
@@ -25,7 +25,9 @@ import {
   Wrench,
   Gauge,
   Target,
-  CheckCircle2
+  CheckCircle2,
+  UserPlus,
+  UserCheck
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { useAuth } from '../../contexts/AuthContext';
@@ -64,6 +66,7 @@ interface ShowcaseProject {
   updated_at: string;
   is_liked: boolean;
   is_bookmarked: boolean;
+  is_following_owner: boolean;
   status: string;
 }
 
@@ -71,17 +74,24 @@ interface ProjectShowcaseCardProps {
   project: ShowcaseProject;
   viewMode: 'grid' | 'list';
   onProjectClick?: (projectId: string) => void;
+  onToggleLike?: () => void;
+  onToggleBookmark?: () => void;
+  onToggleFollow?: () => void;
 }
 
 const ProjectShowcaseCard: React.FC<ProjectShowcaseCardProps> = ({
   project,
   viewMode,
-  onProjectClick
+  onProjectClick,
+  onToggleLike,
+  onToggleBookmark,
+  onToggleFollow,
 }) => {
   const { user } = useAuth();
-  const [isLiked, setIsLiked] = useState(project.is_liked);
-  const [isBookmarked, setIsBookmarked] = useState(project.is_bookmarked);
-  const [likeCount, setLikeCount] = useState(project.like_count);
+  const isLiked = project.is_liked;
+  const isBookmarked = project.is_bookmarked;
+  const likeCount = project.like_count;
+  const isFollowingOwner = project.is_following_owner;
 
   const getDifficultyColor = (level: string) => {
     switch (level) {
@@ -103,47 +113,22 @@ const ProjectShowcaseCard: React.FC<ProjectShowcaseCardProps> = ({
     }
   };
 
-  const handleLike = async (e: React.MouseEvent) => {
+  const handleLike = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!user) return;
-
-    try {
-      const token = localStorage.getItem('auth_token') || 'mock-token';
-      const response = await fetch(`/api/v1/projects/${project.project_id}/like`, {
-        method: isLiked ? 'DELETE' : 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (response.ok) {
-        setIsLiked(!isLiked);
-        setLikeCount(prev => isLiked ? prev - 1 : prev + 1);
-      }
-    } catch (error) {
-      console.error('Error toggling like:', error);
-    }
+    onToggleLike?.();
   };
 
-  const handleBookmark = async (e: React.MouseEvent) => {
+  const handleBookmark = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!user) return;
+    onToggleBookmark?.();
+  };
 
-    try {
-      const token = localStorage.getItem('auth_token') || 'mock-token';
-      const response = await fetch(`/api/v1/projects/${project.project_id}/bookmark`, {
-        method: isBookmarked ? 'DELETE' : 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      });
-
-      if (response.ok) {
-        setIsBookmarked(!isBookmarked);
-      }
-    } catch (error) {
-      console.error('Error toggling bookmark:', error);
-    }
+  const handleFollow = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!user) return;
+    onToggleFollow?.();
   };
 
   const handleShare = async (e: React.MouseEvent) => {
@@ -288,6 +273,18 @@ const ProjectShowcaseCard: React.FC<ProjectShowcaseCardProps> = ({
                   >
                     <Bookmark className={`h-4 w-4 ${isBookmarked ? 'fill-current' : ''}`} />
                   </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleFollow}
+                    className={isFollowingOwner ? 'text-green-600' : 'text-gray-500'}
+                  >
+                    {isFollowingOwner ? (
+                      <UserCheck className="h-4 w-4" />
+                    ) : (
+                      <UserPlus className="h-4 w-4" />
+                    )}
+                  </Button>
                   <Button variant="ghost" size="sm" onClick={handleShare}>
                     <Share2 className="h-4 w-4" />
                   </Button>
@@ -394,6 +391,18 @@ const ProjectShowcaseCard: React.FC<ProjectShowcaseCardProps> = ({
             className={`shadow-lg ${isBookmarked ? 'text-blue-500' : ''}`}
           >
             <Bookmark className={`h-4 w-4 ${isBookmarked ? 'fill-current' : ''}`} />
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleFollow}
+            className={`shadow-lg ${isFollowingOwner ? 'text-green-600' : ''}`}
+          >
+            {isFollowingOwner ? (
+              <UserCheck className="h-4 w-4" />
+            ) : (
+              <UserPlus className="h-4 w-4" />
+            )}
           </Button>
         </div>
       </div>

--- a/frontend/makrcave-frontend/pages/ProjectShowcase.tsx
+++ b/frontend/makrcave-frontend/pages/ProjectShowcase.tsx
@@ -200,6 +200,61 @@ const ProjectShowcase: React.FC = () => {
     }
   };
 
+  const toggleLike = async (projectId: string) => {
+    const project = projects.find(p => p.project_id === projectId);
+    if (!project) return;
+    try {
+      const token = localStorage.getItem('auth_token') || 'mock-token';
+      const method = project.is_liked ? 'DELETE' : 'POST';
+      const response = await fetch(`/api/v1/projects/${projectId}/like`, {
+        method,
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setProjects(prev => prev.map(p => p.project_id === projectId ? { ...p, is_liked: !p.is_liked, like_count: data.like_count } : p));
+      }
+    } catch (err) {
+      console.error('Error toggling like:', err);
+    }
+  };
+
+  const toggleBookmark = async (projectId: string) => {
+    const project = projects.find(p => p.project_id === projectId);
+    if (!project) return;
+    try {
+      const token = localStorage.getItem('auth_token') || 'mock-token';
+      const method = project.is_bookmarked ? 'DELETE' : 'POST';
+      const response = await fetch(`/api/v1/projects/${projectId}/bookmark`, {
+        method,
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        setProjects(prev => prev.map(p => p.project_id === projectId ? { ...p, is_bookmarked: !p.is_bookmarked } : p));
+      }
+    } catch (err) {
+      console.error('Error toggling bookmark:', err);
+    }
+  };
+
+  const toggleFollow = async (projectId: string) => {
+    const project = projects.find(p => p.project_id === projectId);
+    if (!project) return;
+    try {
+      const token = localStorage.getItem('auth_token') || 'mock-token';
+      const method = project.is_following_owner ? 'DELETE' : 'POST';
+      const response = await fetch(`/api/v1/projects/${projectId}/follow`, {
+        method,
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (response.ok) {
+        setProjects(prev => prev.map(p => p.project_id === projectId ? { ...p, is_following_owner: !p.is_following_owner } : p));
+      }
+    } catch (err) {
+      console.error('Error toggling follow:', err);
+    }
+  };
+
   const applyFilters = () => {
     let filtered = [...projects];
 
@@ -566,6 +621,9 @@ const ProjectShowcase: React.FC = () => {
                     key={project.project_id}
                     project={project}
                     viewMode={viewMode}
+                    onToggleLike={() => toggleLike(project.project_id)}
+                    onToggleBookmark={() => toggleBookmark(project.project_id)}
+                    onToggleFollow={() => toggleFollow(project.project_id)}
                   />
                 ))}
               </div>

--- a/makrcave-backend/init_db.py
+++ b/makrcave-backend/init_db.py
@@ -16,8 +16,15 @@ from database import init_db, get_db_session, reset_db
 from models.inventory import InventoryItem, InventoryUsageLog, InventoryAlert
 from models.equipment import Equipment, EquipmentMaintenanceLog, EquipmentReservation, EquipmentRating
 from models.project import (
-    Project, ProjectCollaborator, ProjectBOM, ProjectEquipmentReservation,
-    ProjectFile, ProjectMilestone, ProjectActivityLog
+    Project,
+    ProjectCollaborator,
+    ProjectBOM,
+    ProjectEquipmentReservation,
+    ProjectFile,
+    ProjectMilestone,
+    ProjectActivityLog,
+    ProjectLike,
+    ProjectBookmark,
 )
 from schemas.inventory import SupplierType, ItemStatus, UsageAction, AccessLevel
 from schemas.equipment import EquipmentStatus, EquipmentCategory, ReservationStatus

--- a/makrcave-backend/migrations/create_member_tables.py
+++ b/makrcave-backend/migrations/create_member_tables.py
@@ -12,7 +12,15 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy import create_engine, text
-from models.member import Base, Member, MembershipPlan, MemberInvite, MemberActivityLog, MembershipTransaction
+from models.member import (
+    Base,
+    Member,
+    MembershipPlan,
+    MemberInvite,
+    MemberActivityLog,
+    MembershipTransaction,
+    MemberFollow,
+)
 from database import DATABASE_URL, engine
 import logging
 
@@ -30,7 +38,8 @@ def create_member_tables():
             Member.__table__,
             MemberInvite.__table__,
             MemberActivityLog.__table__,
-            MembershipTransaction.__table__
+            MembershipTransaction.__table__,
+            MemberFollow.__table__,
         ])
         
         logger.info("Member tables created successfully!")

--- a/makrcave-backend/models/member.py
+++ b/makrcave-backend/models/member.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Integer, Boolean, DateTime, Float, Text, ForeignKey, JSON, Enum
+from sqlalchemy import Column, String, Integer, Boolean, DateTime, Float, Text, ForeignKey, JSON, Enum, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
@@ -187,6 +187,20 @@ class MembershipTransaction(Base):
     member = relationship("Member")
     membership_plan = relationship("MembershipPlan")
 
+
+class MemberFollow(Base):
+    """Track user follow relationships"""
+    __tablename__ = "member_follows"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    follower_id = Column(String(100), nullable=False, index=True)
+    followed_id = Column(String(100), nullable=False, index=True)
+    followed_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("follower_id", "followed_id", name="uq_member_follow"),
+    )
+
 # Indexes for better performance
 from sqlalchemy import Index
 
@@ -202,3 +216,5 @@ Index('idx_invite_status', MemberInvite.status)
 Index('idx_activity_member', MemberActivityLog.member_id)
 Index('idx_activity_type', MemberActivityLog.activity_type)
 Index('idx_transaction_member', MembershipTransaction.member_id)
+Index('idx_follow_follower', MemberFollow.follower_id)
+Index('idx_follow_followed', MemberFollow.followed_id)

--- a/makrcave-backend/models/project.py
+++ b/makrcave-backend/models/project.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, DateTime, Boolean, ForeignKey, Integer, Float, JSON, Enum
+from sqlalchemy import Column, String, Text, DateTime, Boolean, ForeignKey, Integer, Float, JSON, Enum, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import enum
@@ -346,6 +346,23 @@ class ProjectLike(Base):
     liked_at = Column(DateTime(timezone=True), server_default=func.now())
 
     # Relationships
+    project = relationship("Project", foreign_keys=[project_id])
+
+
+class ProjectBookmark(Base):
+    """Track project bookmarks"""
+    __tablename__ = "project_bookmarks"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    project_id = Column(String(100), ForeignKey("projects.project_id"), nullable=False)
+    user_id = Column(String(100), nullable=False, index=True)
+
+    bookmarked_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("project_id", "user_id", name="uq_project_bookmark"),
+    )
+
     project = relationship("Project", foreign_keys=[project_id])
 
 class ProjectComment(Base):


### PR DESCRIPTION
## Summary
- add ProjectBookmark and MemberFollow models for user interactions
- implement like, bookmark, and follow logic in project showcase routes
- wire frontend showcase page to toggle interactions and show follow status

## Testing
- `python -m py_compile makrcave-backend/models/project.py makrcave-backend/models/member.py makrcave-backend/init_db.py makrcave-backend/migrations/create_member_tables.py makrcave-backend/routes/project_showcase.py`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689a372cd5a483269e2f38bc0dc4ef48