### PR TITLE
Add package initializers and relative imports to MakrCave backend

### DIFF
--- a/makrcave-backend/__init__.py
+++ b/makrcave-backend/__init__.py
@@ -1,0 +1,5 @@
+"""MakrCave backend package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/crud/__init__.py
+++ b/makrcave-backend/crud/__init__.py
@@ -1,0 +1,5 @@
+"""CRUD operations package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/crud/analytics.py
+++ b/makrcave-backend/crud/analytics.py
@@ -4,11 +4,11 @@ from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime, date, timedelta
 import uuid
 
-from models.analytics import (
+from ..models.analytics import (
     UsageEvent, AnalyticsSnapshot, ReportRequest, EquipmentUsageLog,
     InventoryAnalytics, ProjectAnalytics, RevenueAnalytics, EventType
 )
-from schemas.analytics import (
+from ..schemas.analytics import (
     UsageEventCreate, ReportRequestCreate, EquipmentUsageLogCreate,
     InventoryAnalyticsCreate, ProjectAnalyticsCreate, RevenueAnalyticsCreate,
     AnalyticsFilters, TimePeriodEnum
@@ -67,7 +67,7 @@ class AnalyticsCRUD:
 
         if total_events == 0:
             # No data available, use mock data
-            from utils.analytics_mock_data import get_mock_analytics_overview
+            from ..utils.analytics_mock_data import get_mock_analytics_overview
             return get_mock_analytics_overview()
         today = datetime.now().date()
         week_ago = today - timedelta(days=7)
@@ -134,7 +134,7 @@ class AnalyticsCRUD:
         ).scalar() or 0
 
         if total_events == 0:
-            from utils.analytics_mock_data import get_mock_usage_stats
+            from ..utils.analytics_mock_data import get_mock_usage_stats
             return get_mock_usage_stats(period.value)
         end_date = datetime.now()
         

--- a/makrcave-backend/crud/inventory.py
+++ b/makrcave-backend/crud/inventory.py
@@ -4,11 +4,11 @@ from typing import List, Optional, Dict, Any
 import uuid
 from datetime import datetime, timedelta
 
-from models.inventory import (
+from ..models.inventory import (
     InventoryItem, InventoryUsageLog, InventoryAlert, BulkImportJob,
     ItemStatus, SupplierType, AccessLevel, UsageAction
 )
-from schemas.inventory import (
+from ..schemas.inventory import (
     InventoryItemCreate, InventoryItemUpdate, InventoryFilter,
     InventoryUsageLogCreate, BulkUpdateRequest, BulkIssueRequest
 )

--- a/makrcave-backend/crud/skill.py
+++ b/makrcave-backend/crud/skill.py
@@ -4,8 +4,8 @@ from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta
 import uuid
 
-from models.skill import Skill, UserSkill, SkillRequest, SkillAuditLog, SkillStatus, RequestStatus
-from schemas.skill import (
+from ..models.skill import Skill, UserSkill, SkillRequest, SkillAuditLog, SkillStatus, RequestStatus
+from ..schemas.skill import (
     SkillCreate, SkillUpdate, UserSkillCreate, UserSkillUpdate,
     SkillRequestCreate, SkillRequestUpdate, EquipmentAccessCheck
 )
@@ -301,7 +301,7 @@ def update_skill_request(db: Session, request_id: str, request_update: SkillRequ
 # Equipment Access Control
 def check_equipment_access(db: Session, user_id: str, equipment_id: str) -> EquipmentAccessCheck:
     # Get equipment's required skills
-    from models.equipment import Equipment
+    from ..models.equipment import Equipment
     equipment = db.query(Equipment).options(joinedload(Equipment.required_skills)).filter(Equipment.id == equipment_id).first()
     
     if not equipment:
@@ -351,7 +351,7 @@ def check_equipment_access(db: Session, user_id: str, equipment_id: str) -> Equi
     )
 
 def get_user_accessible_equipment(db: Session, user_id: str, makerspace_id: Optional[str] = None) -> List[str]:
-    from models.equipment import Equipment
+    from ..models.equipment import Equipment
     
     query = db.query(Equipment)
     if makerspace_id:

--- a/makrcave-backend/init_db.py
+++ b/makrcave-backend/init_db.py
@@ -12,10 +12,10 @@ from datetime import datetime
 # Add the backend directory to the Python path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from database import init_db, get_db_session, reset_db
-from models.inventory import InventoryItem, InventoryUsageLog, InventoryAlert
-from models.equipment import Equipment, EquipmentMaintenanceLog, EquipmentReservation, EquipmentRating
-from models.project import (
+from .database import init_db, get_db_session, reset_db
+from .models.inventory import InventoryItem, InventoryUsageLog, InventoryAlert
+from .models.equipment import Equipment, EquipmentMaintenanceLog, EquipmentReservation, EquipmentRating
+from .models.project import (
     Project,
     ProjectCollaborator,
     ProjectBOM,
@@ -26,8 +26,8 @@ from models.project import (
     ProjectLike,
     ProjectBookmark,
 )
-from schemas.inventory import SupplierType, ItemStatus, UsageAction, AccessLevel
-from schemas.equipment import EquipmentStatus, EquipmentCategory, ReservationStatus
+from .schemas.inventory import SupplierType, ItemStatus, UsageAction, AccessLevel
+from .schemas.equipment import EquipmentStatus, EquipmentCategory, ReservationStatus
 
 def create_sample_data():
     """Create sample inventory data for testing"""

--- a/makrcave-backend/main.py
+++ b/makrcave-backend/main.py
@@ -5,30 +5,30 @@ import uvicorn
 import os
 
 # Import security middleware
-from middleware.security import add_security_middleware
+from .middleware.security import add_security_middleware
 
-from routes.inventory import router as inventory_router
-from routes.equipment import router as equipment_router
-from routes.project import router as project_router
-from routes.member import router as member_router
-from routes.billing import router as billing_router
-from routes.analytics import router as analytics_router
-from routes.makerspace_settings import router as settings_router
-from routes.skill import router as skill_router
-from routes.bridge import router as bridge_router
-from routes.membership_plans import router as membership_plans_router
-from routes.announcements import router as announcements_router
-from routes.filament_tracking import router as filament_tracking_router
-from routes.enhanced_projects import router as enhanced_projects_router
-from routes.equipment_reservations import router as equipment_reservations_router
-from routes.job_management import router as job_management_router
-from routes.machine_access import router as machine_access_router
-from routes.enhanced_bom import router as enhanced_bom_router
-from routes.access_control import router as access_control_router
-from routes.enhanced_analytics import router as enhanced_analytics_router
-from routes.notifications import router as notifications_router
-from routes.collaboration import router as collaboration_router
-from routes.project_showcase import router as project_showcase_router
+from .routes.inventory import router as inventory_router
+from .routes.equipment import router as equipment_router
+from .routes.project import router as project_router
+from .routes.member import router as member_router
+from .routes.billing import router as billing_router
+from .routes.analytics import router as analytics_router
+from .routes.makerspace_settings import router as settings_router
+from .routes.skill import router as skill_router
+from .routes.bridge import router as bridge_router
+from .routes.membership_plans import router as membership_plans_router
+from .routes.announcements import router as announcements_router
+from .routes.filament_tracking import router as filament_tracking_router
+from .routes.enhanced_projects import router as enhanced_projects_router
+from .routes.equipment_reservations import router as equipment_reservations_router
+from .routes.job_management import router as job_management_router
+from .routes.machine_access import router as machine_access_router
+from .routes.enhanced_bom import router as enhanced_bom_router
+from .routes.access_control import router as access_control_router
+from .routes.enhanced_analytics import router as enhanced_analytics_router
+from .routes.notifications import router as notifications_router
+from .routes.collaboration import router as collaboration_router
+from .routes.project_showcase import router as project_showcase_router
 
 # Create FastAPI application
 app = FastAPI(

--- a/makrcave-backend/migrations/__init__.py
+++ b/makrcave-backend/migrations/__init__.py
@@ -1,0 +1,5 @@
+"""Database migrations package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/migrations/create_analytics_tables.py
+++ b/makrcave-backend/migrations/create_analytics_tables.py
@@ -13,9 +13,9 @@ from datetime import datetime
 # Add the backend directory to the Python path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from database import engine, get_db_session
-from models.analytics import Base as AnalyticsBase
-from models.analytics import (
+from ..database import engine, get_db_session
+from ..models.analytics import Base as AnalyticsBase
+from ..models.analytics import (
     UsageEvent, AnalyticsSnapshot, ReportRequest, EquipmentUsageLog,
     InventoryAnalytics, ProjectAnalytics, RevenueAnalytics
 )

--- a/makrcave-backend/migrations/create_member_tables.py
+++ b/makrcave-backend/migrations/create_member_tables.py
@@ -12,7 +12,7 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy import create_engine, text
-from models.member import (
+from ..models.member import (
     Base,
     Member,
     MembershipPlan,
@@ -21,7 +21,7 @@ from models.member import (
     MembershipTransaction,
     MemberFollow,
 )
-from database import DATABASE_URL, engine
+from ..database import DATABASE_URL, engine
 import logging
 
 logging.basicConfig(level=logging.INFO)

--- a/makrcave-backend/migrations/create_skill_tables.py
+++ b/makrcave-backend/migrations/create_skill_tables.py
@@ -11,7 +11,7 @@ This migration creates all tables needed for the skill management system:
 """
 
 from sqlalchemy import text
-from database import engine, Base
+from ..database import engine, Base
 import logging
 
 # Configure logging
@@ -24,7 +24,7 @@ def upgrade():
     
     try:
         # Create tables using SQLAlchemy
-        from models.skill import Skill, UserSkill, SkillRequest, SkillAuditLog, skill_prerequisites, skill_equipment
+        from ..models.skill import Skill, UserSkill, SkillRequest, SkillAuditLog, skill_prerequisites, skill_equipment
         
         # Create all skill-related tables
         Base.metadata.create_all(bind=engine, tables=[

--- a/makrcave-backend/models/__init__.py
+++ b/makrcave-backend/models/__init__.py
@@ -1,0 +1,5 @@
+"""Database models package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/models/analytics.py
+++ b/makrcave-backend/models/analytics.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, String, Integer, Float, DateTime, JSON, Text, Boo
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from database import Base
+from ..database import Base
 import uuid
 from datetime import datetime
 from enum import Enum

--- a/makrcave-backend/models/skill.py
+++ b/makrcave-backend/models/skill.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, String, Text, Boolean, DateTime, ForeignKey, Enum, Table
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
-from database import Base
+from ..database import Base
 import enum
 
 class SkillLevel(str, enum.Enum):

--- a/makrcave-backend/routes/__init__.py
+++ b/makrcave-backend/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API route definitions package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/routes/analytics.py
+++ b/makrcave-backend/routes/analytics.py
@@ -5,10 +5,10 @@ from typing import Dict, Any, Optional
 from datetime import datetime, timedelta
 import logging
 
-from database import get_db
-from dependencies import get_current_user, get_current_makerspace, require_permission
-from services.real_analytics_service import get_real_analytics_service
-from utils.analytics_mock_data import AnalyticsMockData  # Fallback only
+from ..database import get_db
+from ..dependencies import get_current_user, get_current_makerspace, require_permission
+from ..services.real_analytics_service import get_real_analytics_service
+from ..utils.analytics_mock_data import AnalyticsMockData  # Fallback only
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/makrcave-backend/routes/bridge.py
+++ b/makrcave-backend/routes/bridge.py
@@ -9,10 +9,10 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from core.config import settings
-from database import get_db
-from models.project import Job, JobStatus
-from schemas.project import JobCreate, JobUpdate
-from utils.auth import get_current_user
+from ..database import get_db
+from ..models.project import Job, JobStatus
+from ..schemas.project import JobCreate, JobUpdate
+from ..utils.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/makrcave-backend/routes/bridge_contracts.py
+++ b/makrcave-backend/routes/bridge_contracts.py
@@ -9,10 +9,10 @@ from pydantic import BaseModel
 from datetime import datetime
 import httpx
 
-from database import get_db
-from models.project import Job, JobStatus
-from models.inventory import InventoryItem, InventoryTransaction
-from utils.auth import verify_service_jwt
+from ..database import get_db
+from ..models.project import Job, JobStatus
+from ..models.inventory import InventoryItem, InventoryTransaction
+from ..utils.auth import verify_service_jwt
 
 router = APIRouter()
 

--- a/makrcave-backend/routes/skill.py
+++ b/makrcave-backend/routes/skill.py
@@ -2,17 +2,17 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
 
-from database import get_db
-from dependencies import get_current_user, require_role
-from models.skill import SkillStatus, RequestStatus
-from schemas.skill import (
+from ..database import get_db
+from ..dependencies import get_current_user, require_role
+from ..models.skill import SkillStatus, RequestStatus
+from ..schemas.skill import (
     Skill, SkillCreate, SkillUpdate, SkillWithRelations,
     UserSkill, UserSkillCreate, UserSkillUpdate, UserSkillWithDetails,
     SkillRequest, SkillRequestCreate, SkillRequestUpdate, SkillRequestWithDetails,
     EquipmentSkillRequirements, UserSkillSummary, EquipmentAccessCheck,
     BulkAccessCheck, SkillAnalytics, MakerspaceSkillOverview
 )
-from crud import skill as skill_crud
+from ..crud import skill as skill_crud
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 
@@ -299,7 +299,7 @@ async def check_bulk_equipment_access(
     check_user_id = user_id if user_id and current_user.role in ["super_admin", "makerspace_admin"] else current_user.id
     
     # Get all equipment in makerspace
-    from crud.equipment import get_equipment
+    from ..crud.equipment import get_equipment
     equipment_list = get_equipment(db=db, makerspace_id=makerspace_id)
     
     access_checks = []
@@ -332,7 +332,7 @@ async def get_equipment_skill_requirements(
     current_user = Depends(get_current_user)
 ):
     """Get skill requirements for all equipment"""
-    from crud.equipment import get_equipment
+    from ..crud.equipment import get_equipment
     equipment_list = get_equipment(db=db, makerspace_id=makerspace_id)
     
     result = []

--- a/makrcave-backend/schemas/__init__.py
+++ b/makrcave-backend/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Pydantic schemas package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/services/__init__.py
+++ b/makrcave-backend/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/services/real_analytics_service.py
+++ b/makrcave-backend/services/real_analytics_service.py
@@ -7,16 +7,16 @@ from sqlalchemy.sql import case
 import logging
 from collections import defaultdict
 
-from database import get_db
-from models.enhanced_analytics import (
-    UsageMetric, RevenueRecord, EquipmentUsage, 
+from ..database import get_db
+from ..models.enhanced_analytics import (
+    UsageMetric, RevenueRecord, EquipmentUsage,
     MemberActivity, SafetyIncident, SystemHealth
 )
-from models.enhanced_member import Member, MemberSkill, Certification
-from models.equipment import Equipment, EquipmentReservation
-from models.makerspace_settings import MakerspaceSettings
-from models.project import Project
-from models.billing import Transaction, CreditTransaction
+from ..models.enhanced_member import Member, MemberSkill, Certification
+from ..models.equipment import Equipment, EquipmentReservation
+from ..models.makerspace_settings import MakerspaceSettings
+from ..models.project import Project
+from ..models.billing import Transaction, CreditTransaction
 
 logger = logging.getLogger(__name__)
 

--- a/makrcave-backend/utils/__init__.py
+++ b/makrcave-backend/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helper functions package."""
+
+
+__all__: list[str] = []
+

--- a/makrcave-backend/utils/report_generator.py
+++ b/makrcave-backend/utils/report_generator.py
@@ -37,7 +37,7 @@ class ReportGenerator:
     def generate_usage_report_csv(self, makerspace_id: str, start_date: date, end_date: date) -> str:
         """Generate usage analytics CSV report"""
         # Query usage events
-        from models.analytics import UsageEvent
+        from ..models.analytics import UsageEvent
         
         events = self.db.query(UsageEvent).filter(
             UsageEvent.makerspace_id == makerspace_id,
@@ -87,7 +87,7 @@ class ReportGenerator:
 
     def generate_inventory_report_xlsx(self, makerspace_id: str, start_date: date, end_date: date) -> str:
         """Generate inventory analytics Excel report"""
-        from models.analytics import InventoryAnalytics
+        from ..models.analytics import InventoryAnalytics
         
         # Query inventory data
         inventory_data = self.db.query(InventoryAnalytics).filter(
@@ -151,7 +151,7 @@ class ReportGenerator:
 
     def generate_revenue_report_pdf(self, makerspace_id: str, start_date: date, end_date: date) -> str:
         """Generate revenue analytics PDF report"""
-        from models.analytics import RevenueAnalytics
+        from ..models.analytics import RevenueAnalytics
         
         # Query revenue data
         revenue_data = self.db.query(RevenueAnalytics).filter(
@@ -278,7 +278,7 @@ class ReportGenerator:
 
     def generate_equipment_report_xlsx(self, makerspace_id: str, start_date: date, end_date: date) -> str:
         """Generate equipment metrics Excel report"""
-        from models.analytics import EquipmentUsageLog
+        from ..models.analytics import EquipmentUsageLog
         
         usage_logs = self.db.query(EquipmentUsageLog).filter(
             EquipmentUsageLog.makerspace_id == makerspace_id,
@@ -347,7 +347,7 @@ class ReportGenerator:
 
     def generate_projects_report_csv(self, makerspace_id: str, start_date: date, end_date: date) -> str:
         """Generate project analytics CSV report"""
-        from models.analytics import ProjectAnalytics
+        from ..models.analytics import ProjectAnalytics
         
         projects = self.db.query(ProjectAnalytics).filter(
             ProjectAnalytics.makerspace_id == makerspace_id,


### PR DESCRIPTION
## Summary
- add __init__.py files so backend directories are Python packages
- switch intra-package imports to use relative paths for consistent resolution

## Testing
- `python -m flake8 makrcave-backend --select=E9,F63,F7,F82 --show-source --statistics` *(fails: undefined names and syntax errors in existing modules)*
- `python - <<'PY' ...` (py_compile for modified modules)


------
https://chatgpt.com/codex/tasks/task_e_689a3c9a85b083269be31604ec322741