### PR TITLE
feat: connect frontends to live APIs

### DIFF
--- a/makrx-store-frontend/src/app/page.tsx
+++ b/makrx-store-frontend/src/app/page.tsx
@@ -10,6 +10,7 @@ export default function HomePage() {
   const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadData = async () => {
@@ -22,14 +23,7 @@ export default function HomePage() {
         setFeaturedProducts(Array.isArray(productsData) ? productsData : []);
         setCategories(Array.isArray(categoriesData) ? categoriesData : []);
       } catch (error) {
-        // Silently handle errors in development when using mock data
-        if (process.env.NODE_ENV === "development") {
-          console.warn("Using fallback data due to backend unavailability");
-        } else {
-          console.error("Failed to load homepage data:", error);
-        }
-
-        // Set empty arrays as fallback
+        setError(error instanceof Error ? error.message : "Failed to load data");
         setFeaturedProducts([]);
         setCategories([]);
       } finally {
@@ -56,17 +50,16 @@ export default function HomePage() {
     );
   }
 
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-red-600">Failed to load homepage: {error}</p>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-background">
-      {/* Development Mode Notice */}
-      {process.env.NODE_ENV === "development" && typeof window !== "undefined" && sessionStorage.getItem("mock-data-notice-shown") && (
-        <div className="bg-yellow-100 dark:bg-yellow-900 border-b border-yellow-200 dark:border-yellow-800 px-4 py-2">
-          <p className="text-center text-yellow-800 dark:text-yellow-200 text-sm">
-            🔧 Development Mode: Using demo data - Backend service not connected
-          </p>
-        </div>
-      )}
-
       {/* Hero Section */}
       <section className="relative bg-gradient-to-r from-blue-600 to-purple-700 text-white">
         <div className="absolute inset-0 bg-black opacity-20"></div>

--- a/makrx-store-frontend/src/lib/api.ts
+++ b/makrx-store-frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import { adminDataService } from "./adminData";
 // API Configuration
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8003";
 const API_VERSION = "v1";
+const USE_MOCK_API = process.env.NEXT_PUBLIC_USE_MOCK_API === "true";
 
 // Types
 export interface ApiResponse<T> {
@@ -319,9 +320,8 @@ class ApiClient {
     endpoint: string,
     options: RequestInit = {},
   ): Promise<T> {
-    // In development mode, skip backend requests entirely and use mock data
-    if (process.env.NODE_ENV === "development" && this.baseURL.includes("localhost:8003")) {
-      // Show a one-time notification that we're using mock data
+    // Allow forcing mock mode via environment variable
+    if (USE_MOCK_API) {
       if (typeof window !== "undefined" && !sessionStorage.getItem("mock-data-notice-shown")) {
         sessionStorage.setItem("mock-data-notice-shown", "true");
         console.info("🔧 Development Mode: Using mock data for demo purposes (backend requests disabled).");
@@ -377,7 +377,7 @@ class ApiClient {
            error.message.includes("net::ERR"));
 
       // Always use mock data in development for network errors, abort errors, or connection issues
-      if (isAbortError || isNetworkError || isConnectionError || (process.env.NODE_ENV === "development" && url.includes("localhost:8003"))) {
+      if (isAbortError || isNetworkError || isConnectionError) {
         // Show a one-time notification that we're using mock data (but not for abort errors)
         if (!isAbortError && typeof window !== "undefined" && !sessionStorage.getItem("mock-data-notice-shown")) {
           sessionStorage.setItem("mock-data-notice-shown", "true");


### PR DESCRIPTION
## Summary
- add mock API base URL and network error fallback so MakrCave frontend seamlessly switches to mock endpoints when the real backend is unreachable
- allow MakrX Store client to target live backend by default, with optional `NEXT_PUBLIC_USE_MOCK_API` flag and automatic mock fallback on network failures

## Testing
- `npm test`
- `npm run typecheck`
- `npm run typecheck` (frontend/makrcave-frontend: TypeScript errors)
- `npm run typecheck` (makrx-store-frontend: missing script "typecheck")

------
https://chatgpt.com/codex/tasks/task_e_689a49b3ea0c8326b6530bf86fff1d6d