### PR TITLE
feat(auth): add keycloak oidc support

### DIFF
--- a/frontend/makrcave-frontend/lib/auth.ts
+++ b/frontend/makrcave-frontend/lib/auth.ts
@@ -1,0 +1,46 @@
+import Keycloak, { KeycloakConfig } from 'keycloak-js';
+
+const keycloakConfig: KeycloakConfig = {
+  url: import.meta.env.VITE_KEYCLOAK_URL,
+  realm: import.meta.env.VITE_KEYCLOAK_REALM,
+  clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID,
+};
+
+const keycloak = new Keycloak(keycloakConfig);
+
+export const initKeycloak = async () => {
+  const authenticated = await keycloak.init({
+    onLoad: 'check-sso',
+    pkceMethod: 'S256',
+    silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
+    checkLoginIframe: false,
+  });
+
+  if (authenticated) {
+    scheduleRefresh();
+  }
+
+  return authenticated;
+};
+
+function scheduleRefresh() {
+  if (!keycloak.tokenParsed?.exp) return;
+  const refreshTime = (keycloak.tokenParsed.exp * 1000 - Date.now()) * 0.75;
+  window.setTimeout(async () => {
+    try {
+      await keycloak.updateToken(30);
+      scheduleRefresh();
+    } catch (err) {
+      console.error('Token refresh failed', err);
+      login();
+    }
+  }, refreshTime);
+}
+
+export const login = () => keycloak.login();
+export const logout = () => keycloak.logout();
+export const getToken = () => keycloak.token || '';
+export const isAuthenticated = () => Boolean(keycloak.authenticated);
+export const getUser = () => keycloak.tokenParsed as any || null;
+
+export default keycloak;

--- a/frontend/makrcave-frontend/package-lock.json
+++ b/frontend/makrcave-frontend/package-lock.json
@@ -28,6 +28,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "keycloak-js": "^21.1.2",
         "lucide-react": "^0.462.0",
         "react": "^18.3.1",
         "react-calendar": "^4.8.0",
@@ -2947,6 +2948,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3722,11 +3743,27 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/keycloak-js": {
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-21.1.2.tgz",
+      "integrity": "sha512-+6r1BvmutWGJBtibo7bcFbHWIlA7XoXRCwcA4vopeJh59Nv2Js0ju2u+t8AYth+C6Cg7/BNfO3eCTbsl/dTBHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/frontend/makrcave-frontend/package.json
+++ b/frontend/makrcave-frontend/package.json
@@ -42,6 +42,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.15.4",
+    "keycloak-js": "^21.1.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/frontend/makrcave-frontend/public/silent-check-sso.html
+++ b/frontend/makrcave-frontend/public/silent-check-sso.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/frontend/makrcave-frontend/services/apiService.ts
+++ b/frontend/makrcave-frontend/services/apiService.ts
@@ -2,7 +2,7 @@
 // Connects to FastAPI backend with proper JWT authentication
 
 import loggingService from './loggingService';
-import authService from './authService';
+import { getToken } from '../lib/auth';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 const MOCK_API_BASE_URL =
@@ -247,7 +247,7 @@ async function apiCall<T>(
   });
 
   try {
-    const fetchImpl = USE_MOCK_API ? fetch : authService.createAuthenticatedFetch();
+    const token = getToken();
     const baseUrl = USE_MOCK_API ? MOCK_API_BASE_URL : API_BASE_URL;
 
     loggingService.debug('api', 'ApiService.apiCall', 'Making API call', {
@@ -257,9 +257,10 @@ async function apiCall<T>(
       useMock: USE_MOCK_API,
     });
 
-    const response = await fetchImpl(`${baseUrl}${endpoint}`, {
+    const response = await fetch(`${baseUrl}${endpoint}`, {
       headers: {
         'Content-Type': 'application/json',
+        ...(token && { Authorization: `Bearer ${token}` }),
         ...options.headers,
       },
       ...options,

--- a/makrx-store-frontend/package-lock.json
+++ b/makrx-store-frontend/package-lock.json
@@ -26,6 +26,7 @@
         "clsx": "^2.0.0",
         "framer-motion": "^10.16.0",
         "jwt-decode": "^4.0.0",
+        "keycloak-js": "^21.1.2",
         "lucide-react": "^0.462.0",
         "next": "^14.0.0",
         "postcss": "^8.4.0",
@@ -2400,6 +2401,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4764,6 +4785,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4840,6 +4867,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/keycloak-js": {
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-21.1.2.tgz",
+      "integrity": "sha512-+6r1BvmutWGJBtibo7bcFbHWIlA7XoXRCwcA4vopeJh59Nv2Js0ju2u+t8AYth+C6Cg7/BNfO3eCTbsl/dTBHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
       }
     },
     "node_modules/keyv": {

--- a/makrx-store-frontend/package.json
+++ b/makrx-store-frontend/package.json
@@ -29,6 +29,7 @@
     "clsx": "^2.0.0",
     "framer-motion": "^10.16.0",
     "jwt-decode": "^4.0.0",
+    "keycloak-js": "^21.1.2",
     "lucide-react": "^0.462.0",
     "next": "^14.0.0",
     "postcss": "^8.4.0",

--- a/makrx-store-frontend/public/silent-check-sso.html
+++ b/makrx-store-frontend/public/silent-check-sso.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/makrx-store-frontend/src/contexts/AuthContext.tsx
+++ b/makrx-store-frontend/src/contexts/AuthContext.tsx
@@ -34,6 +34,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Initialize auth state
     const initAuth = async () => {
       try {
+        await auth.init();
         const currentUser = auth.getCurrentUser();
         setUser(currentUser);
       } catch (error) {

--- a/makrx-store-frontend/src/lib/auth.ts
+++ b/makrx-store-frontend/src/lib/auth.ts
@@ -1,381 +1,91 @@
-/**
- * Authentication integration with Keycloak
- * JWT token management and user authentication
- */
+import Keycloak, { KeycloakConfig } from 'keycloak-js';
 
-import { jwtDecode } from "jwt-decode";
+const keycloakConfig: KeycloakConfig = {
+  url: process.env.NEXT_PUBLIC_KEYCLOAK_URL || 'https://auth.makrx.org',
+  realm: process.env.NEXT_PUBLIC_KEYCLOAK_REALM || 'makrx',
+  clientId: process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || 'makrx-store',
+};
 
-// Configuration
-const KEYCLOAK_URL =
-  process.env.NEXT_PUBLIC_KEYCLOAK_URL || "https://auth.makrx.org";
-const REALM = process.env.NEXT_PUBLIC_KEYCLOAK_REALM || "makrx";
-const CLIENT_ID = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || "makrx-store";
+const keycloak = new Keycloak(keycloakConfig);
 
-// Types
 export interface User {
   sub: string;
-  email: string;
-  name: string;
-  preferred_username: string;
-  email_verified: boolean;
+  email?: string;
+  name?: string;
+  preferred_username?: string;
+  email_verified?: boolean;
   roles: string[];
   scopes: string[];
 }
 
-export interface AuthTokens {
-  access_token: string;
-  refresh_token: string;
-  expires_in: number;
-  refresh_expires_in: number;
-  token_type: string;
-}
-
-// Token storage keys
-const ACCESS_TOKEN_KEY = "makrx_access_token";
-const REFRESH_TOKEN_KEY = "makrx_refresh_token";
-const TOKEN_EXPIRES_KEY = "makrx_token_expires";
-const USER_INFO_KEY = "makrx_user_info";
-
-// Auth state management
 let currentUser: User | null = null;
-let authListeners: Array<(user: User | null) => void> = [];
+let listeners: Array<(user: User | null) => void> = [];
 
-// Utility functions
-const isClient = typeof window !== "undefined";
-
-const getStoredItem = (key: string): string | null => {
-  if (!isClient) return null;
-  return localStorage.getItem(key);
-};
-
-const setStoredItem = (key: string, value: string): void => {
-  if (!isClient) return;
-  localStorage.setItem(key, value);
-};
-
-const removeStoredItem = (key: string): void => {
-  if (!isClient) return;
-  localStorage.removeItem(key);
-};
-
-// Token management
-export const getToken = async (): Promise<string | null> => {
-  const token = getStoredItem(ACCESS_TOKEN_KEY);
-  const expiresAt = getStoredItem(TOKEN_EXPIRES_KEY);
-
-  if (!token || !expiresAt) {
-    return null;
-  }
-
-  // Check if token is expired
-  const now = Date.now();
-  const expires = parseInt(expiresAt, 10);
-
-  if (now >= expires) {
-    // Try to refresh token
-    const refreshed = await refreshToken();
-    if (refreshed) {
-      return getStoredItem(ACCESS_TOKEN_KEY);
-    }
-    return null;
-  }
-
-  return token;
-};
-
-export const setTokens = (tokens: AuthTokens): void => {
-  const expiresAt = Date.now() + tokens.expires_in * 1000;
-
-  setStoredItem(ACCESS_TOKEN_KEY, tokens.access_token);
-  setStoredItem(REFRESH_TOKEN_KEY, tokens.refresh_token);
-  setStoredItem(TOKEN_EXPIRES_KEY, expiresAt.toString());
-
-  // Decode and store user info
-  try {
-    const decoded = jwtDecode<any>(tokens.access_token);
-    const user: User = {
-      sub: decoded.sub,
-      email: decoded.email,
-      name: decoded.name,
-      preferred_username: decoded.preferred_username,
-      email_verified: decoded.email_verified || false,
-      roles: decoded.realm_access?.roles || [],
-      scopes: (decoded.scope || "").split(" "),
-    };
-
-    setStoredItem(USER_INFO_KEY, JSON.stringify(user));
-    currentUser = user;
-    notifyAuthListeners(user);
-  } catch (error) {
-    console.error("Failed to decode token:", error);
-  }
-};
-
-export const clearTokens = (): void => {
-  removeStoredItem(ACCESS_TOKEN_KEY);
-  removeStoredItem(REFRESH_TOKEN_KEY);
-  removeStoredItem(TOKEN_EXPIRES_KEY);
-  removeStoredItem(USER_INFO_KEY);
-
-  currentUser = null;
-  notifyAuthListeners(null);
-};
-
-// Token refresh
-export const refreshToken = async (): Promise<boolean> => {
-  const refreshTokenValue = getStoredItem(REFRESH_TOKEN_KEY);
-
-  if (!refreshTokenValue) {
-    return false;
-  }
-
-  try {
-    const response = await fetch(
-      `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({
-          grant_type: "refresh_token",
-          client_id: CLIENT_ID,
-          refresh_token: refreshTokenValue,
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      clearTokens();
-      return false;
-    }
-
-    const tokens: AuthTokens = await response.json();
-    setTokens(tokens);
-    return true;
-  } catch (error) {
-    // In development, silently handle auth errors
-    if (process.env.NODE_ENV === "development") {
-      console.warn("Auth service unavailable in development mode");
-    } else {
-      console.error("Token refresh failed:", error);
-    }
-    clearTokens();
-    return false;
-  }
-};
-
-// User management
-export const getCurrentUser = (): User | null => {
-  if (currentUser) {
-    return currentUser;
-  }
-
-  // Try to load from storage
-  const userInfo = getStoredItem(USER_INFO_KEY);
-  if (userInfo) {
-    try {
-      currentUser = JSON.parse(userInfo);
-      return currentUser;
-    } catch (error) {
-      console.error("Failed to parse stored user info:", error);
-    }
-  }
-
-  return null;
-};
-
-export const isAuthenticated = (): boolean => {
-  return getCurrentUser() !== null && getToken() !== null;
-};
-
-export const hasRole = (role: string): boolean => {
-  const user = getCurrentUser();
-  return user?.roles.includes(role) || false;
-};
-
-export const hasAnyRole = (roles: string[]): boolean => {
-  const user = getCurrentUser();
-  return roles.some((role) => user?.roles.includes(role)) || false;
-};
-
-export const hasScope = (scope: string): boolean => {
-  const user = getCurrentUser();
-  return user?.scopes.includes(scope) || false;
-};
-
-// Authentication flow
-export const login = (redirectUri?: string): void => {
-  if (!isClient) return;
-
-  // Store the current location for post-login redirect
-  setStoredItem(
-    "makrx_pre_login_url",
-    window.location.pathname + window.location.search,
-  );
-
-  // Store original URL in session storage for SSO consistency
-  sessionStorage.setItem('makrx_redirect_url', window.location.href);
-
-  const params = new URLSearchParams({
-    client_id: CLIENT_ID,
-    redirect_uri: redirectUri || window.location.origin + "/auth/callback",
-    response_type: "code",
-    scope: "openid email profile",
-    state: generateState(),
-  });
-
-  // Redirect to auth.makrx.org (centralized SSO)
-  window.location.href = `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/auth?${params}`;
-};
-
-export const logout = async (): Promise<void> => {
-  const token = await getToken();
-
-  // Clear local tokens
-  clearTokens();
-
-  // Redirect to Keycloak logout
-  if (isClient && token) {
-    const params = new URLSearchParams({
-      client_id: CLIENT_ID,
-      post_logout_redirect_uri: window.location.origin,
-    });
-
-    window.location.href = `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/logout?${params}`;
-  }
-};
-
-// Handle auth callback
-export const handleAuthCallback = async (
-  code: string,
-  state: string,
-): Promise<boolean> => {
-  if (!isClient) return false;
-
-  try {
-    // Verify state parameter (basic CSRF protection)
-    const storedState = getStoredItem("makrx_auth_state");
-    if (state !== storedState) {
-      throw new Error("Invalid state parameter");
-    }
-
-    // Exchange code for tokens
-    const response = await fetch(
-      `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({
-          grant_type: "authorization_code",
-          client_id: CLIENT_ID,
-          code,
-          redirect_uri: window.location.origin + "/auth/callback",
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error("Token exchange failed");
-    }
-
-    const tokens: AuthTokens = await response.json();
-    setTokens(tokens);
-
-    // Clean up state
-    removeStoredItem("makrx_auth_state");
-
-    return true;
-  } catch (error) {
-    // In development, silently handle auth errors
-    if (process.env.NODE_ENV === "development") {
-      console.warn("Auth service unavailable in development mode");
-    } else {
-      console.error("Auth callback failed:", error);
-    }
-    clearTokens();
-    return false;
-  }
-};
-
-// Utility functions
-const generateState = (): string => {
-  const state =
-    Math.random().toString(36).substring(2, 15) +
-    Math.random().toString(36).substring(2, 15);
-  setStoredItem("makrx_auth_state", state);
-  return state;
-};
-
-// Auth listeners
-export const addAuthListener = (
-  listener: (user: User | null) => void,
-): void => {
-  authListeners.push(listener);
-};
-
-export const removeAuthListener = (
-  listener: (user: User | null) => void,
-): void => {
-  authListeners = authListeners.filter((l) => l !== listener);
-};
-
-const notifyAuthListeners = (user: User | null): void => {
-  authListeners.forEach((listener) => {
-    try {
-      listener(user);
-    } catch (error) {
-      console.error("Auth listener error:", error);
-    }
-  });
-};
-
-// Initialize auth state on load
-if (isClient) {
-  // Check if we have valid tokens and user info
-  const token = getStoredItem(ACCESS_TOKEN_KEY);
-  const userInfo = getStoredItem(USER_INFO_KEY);
-
-  if (token && userInfo) {
-    try {
-      currentUser = JSON.parse(userInfo);
-
-      // Verify token is still valid
-      getToken().then((validToken) => {
-        if (!validToken) {
-          clearTokens();
-        }
-      });
-    } catch (error) {
-      console.error("Failed to initialize auth state:", error);
-      clearTokens();
-    }
-  }
+function notify() {
+  listeners.forEach(l => l(currentUser));
 }
 
-// Auto-refresh token before expiry
-if (isClient) {
-  setInterval(async () => {
-    const token = getStoredItem(ACCESS_TOKEN_KEY);
-    const expiresAt = getStoredItem(TOKEN_EXPIRES_KEY);
+export const init = async () => {
+  const authenticated = await keycloak.init({
+    onLoad: 'check-sso',
+    pkceMethod: 'S256',
+    silentCheckSsoRedirectUri:
+      typeof window !== 'undefined'
+        ? `${window.location.origin}/silent-check-sso.html`
+        : undefined,
+    checkLoginIframe: false,
+  });
 
-    if (token && expiresAt) {
-      const expires = parseInt(expiresAt, 10);
-      const now = Date.now();
-      const timeUntilExpiry = expires - now;
-
-      // Refresh if token expires in less than 5 minutes
-      if (timeUntilExpiry < 5 * 60 * 1000 && timeUntilExpiry > 0) {
-        await refreshToken();
+  if (authenticated) {
+    updateUser();
+    keycloak.onTokenExpired = async () => {
+      try {
+        await keycloak.updateToken(30);
+        updateUser();
+      } catch {
+        login();
       }
-    }
-  }, 60 * 1000); // Check every minute
+    };
+  }
+};
+
+function updateUser() {
+  if (keycloak.tokenParsed) {
+    currentUser = {
+      sub: keycloak.tokenParsed.sub as string,
+      email: keycloak.tokenParsed.email as string | undefined,
+      name: keycloak.tokenParsed.name as string | undefined,
+      preferred_username: keycloak.tokenParsed.preferred_username as string | undefined,
+      email_verified: (keycloak.tokenParsed.email_verified as boolean) || false,
+      roles: (keycloak.tokenParsed.realm_access?.roles as string[]) || [],
+      scopes: (keycloak.tokenParsed.scope as string)?.split(' ') || [],
+    };
+    notify();
+  }
 }
 
-// Export auth utilities
+export const login = () => keycloak.login();
+export const logout = () => keycloak.logout();
+export const getToken = async () => {
+  if (keycloak.authenticated) {
+    try {
+      await keycloak.updateToken(30);
+    } catch {
+      login();
+    }
+  }
+  return keycloak.token ?? null;
+};
+export const getCurrentUser = () => currentUser;
+export const isAuthenticated = () => keycloak.authenticated ?? false;
+export const hasRole = (role: string) => currentUser?.roles.includes(role) ?? false;
+export const hasAnyRole = (roles: string[]) => roles.some(hasRole);
+export const hasScope = (scope: string) => currentUser?.scopes.includes(scope) ?? false;
+export const addAuthListener = (l: (u: User | null) => void) => { listeners.push(l); };
+export const removeAuthListener = (l: (u: User | null) => void) => { listeners = listeners.filter(fn => fn !== l); };
+
 export const auth = {
+  init,
   login,
   logout,
   getToken,


### PR DESCRIPTION
## Summary
- add Keycloak client and auth utilities for MakrCave and Store frontends
- hook API layers to send bearer tokens
- initialize auth contexts with token refresh and silent SSO support

## Testing
- `cd frontend/makrcave-frontend && npm run typecheck` *(fails: Property 'env' does not exist on type 'ImportMeta', ...)*
- `cd ../../makrx-store-frontend && npm run type-check` *(fails: Property 'featured' does not exist on type 'Product', ...)*

------
https://chatgpt.com/codex/tasks/task_e_689ae53a25dc8326b3d96229d487d3f3