### PR TITLE
refactor: use auth helper for token

### DIFF
--- a/frontend/makrcave-frontend/contexts/PortalAuthContext.tsx
+++ b/frontend/makrcave-frontend/contexts/PortalAuthContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { useAuth } from "./AuthContext";
+import { getToken } from "../lib/auth";
 
 interface PortalAuthContextValue {
   handlePortalAuth: () => void;
@@ -145,7 +146,7 @@ export class PortalAwareApiService {
     }
 
     // Add standard auth token if available
-    const authToken = localStorage.getItem("auth_token");
+    const authToken = getToken();
     if (authToken) {
       headers["Authorization"] = `Bearer ${authToken}`;
     }

--- a/frontend/makrcave-frontend/services/apiService.ts
+++ b/frontend/makrcave-frontend/services/apiService.ts
@@ -618,6 +618,21 @@ export const makerspaceApi = {
     });
   },
 
+  updateSettingsSection: async (section: string, data: any): Promise<ApiResponse<MakerspaceSettings>> => {
+    return apiCall<MakerspaceSettings>(`/makerspace/settings/section/${section}`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  },
+
+  exportSettings: async (): Promise<ApiResponse<any>> => {
+    return apiCall<any>('/makerspace/settings/export');
+  },
+
+  resetSettings: async (): Promise<ApiResponse<{ message: string }>> => {
+    return apiCall<{ message: string }>('/makerspace/settings', { method: 'DELETE' });
+  },
+
   // Get subscription options
   getSubscriptionOptions: async (): Promise<ApiResponse<any[]>> => {
     return apiCall<any[]>('/makerspace/subscription-options');

--- a/frontend/makrcave-frontend/services/billingApi.ts
+++ b/frontend/makrcave-frontend/services/billingApi.ts
@@ -2,6 +2,7 @@
 // Connects frontend components with the backend billing system
 
 import loggingService from './loggingService';
+import { getToken } from '../lib/auth';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
@@ -322,7 +323,7 @@ async function apiCall<T>(
 
   // Try real API call for local development
   try {
-    const token = localStorage.getItem('auth_token') || localStorage.getItem('authToken');
+    const token = getToken();
 
     loggingService.debug('api', 'BillingApi.apiCall', 'Making real API call', {
       endpoint,

--- a/frontend/makrcave-frontend/services/fileUploadService.ts
+++ b/frontend/makrcave-frontend/services/fileUploadService.ts
@@ -3,6 +3,8 @@
  * Handles file uploads for profile images, documents, and other assets
  */
 
+import { getToken } from '../lib/auth';
+
 export interface UploadOptions {
   maxSize?: number; // in bytes
   allowedTypes?: string[];
@@ -58,7 +60,7 @@ class FileUploadService {
       formData.append('type', this.getFileType(file));
 
       // Get auth token
-      const token = localStorage.getItem('auth_token') || localStorage.getItem('makrx_access_token');
+      const token = getToken();
 
       // Upload file
       const response = await fetch(`${this.baseUrl}/api/v1/upload`, {
@@ -283,7 +285,7 @@ class FileUploadService {
    */
   async deleteFile(filename: string): Promise<boolean> {
     try {
-      const token = localStorage.getItem('auth_token') || localStorage.getItem('makrx_access_token');
+      const token = getToken();
 
       const response = await fetch(`${this.baseUrl}/api/v1/upload/${filename}`, {
         method: 'DELETE',
@@ -313,7 +315,7 @@ class FileUploadService {
    */
   async getUploads(): Promise<any[]> {
     try {
-      const token = localStorage.getItem('auth_token') || localStorage.getItem('makrx_access_token');
+      const token = getToken();
 
       const response = await fetch(`${this.baseUrl}/api/v1/uploads`, {
         headers: {


### PR DESCRIPTION
## Summary
- replace direct localStorage token access with `getToken`
- extend API service with makerspace settings helpers
- refactor Settings page to use centralized API service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ae97f15c08326a4067c8911fea366