### PR TITLE
Refresh Keycloak token before API calls

### DIFF
--- a/frontend/gateway-frontend/lib/api.ts
+++ b/frontend/gateway-frontend/lib/api.ts
@@ -2,7 +2,7 @@ import { getToken } from './auth';
 
 export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
-  const token = getToken();
+  const token = await getToken();
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
   }

--- a/frontend/gateway-frontend/lib/auth.ts
+++ b/frontend/gateway-frontend/lib/auth.ts
@@ -39,7 +39,16 @@ function setupTokenRefresh() {
 
 export const login = () => keycloak.login();
 export const logout = () => keycloak.logout();
-export const getToken = () => keycloak.token ?? '';
+export const getToken = async () => {
+  try {
+    await keycloak.updateToken(30);
+    return keycloak.token ?? '';
+  } catch (err) {
+    console.error('Token refresh failed', err);
+    login();
+    return '';
+  }
+};
 export const isAuthenticated = () => Boolean(keycloak.authenticated);
 
 export default keycloak;

--- a/frontend/makrcave-frontend/contexts/PortalAuthContext.tsx
+++ b/frontend/makrcave-frontend/contexts/PortalAuthContext.tsx
@@ -134,7 +134,7 @@ export class PortalAwareApiService {
     this.baseURL = baseURL;
   }
 
-  private getHeaders(): HeadersInit {
+  private async getHeaders(): Promise<HeadersInit> {
     const headers: HeadersInit = {
       "Content-Type": "application/json",
     };
@@ -146,7 +146,7 @@ export class PortalAwareApiService {
     }
 
     // Add standard auth token if available
-    const authToken = getToken();
+    const authToken = await getToken();
     if (authToken) {
       headers["Authorization"] = `Bearer ${authToken}`;
     }
@@ -157,7 +157,7 @@ export class PortalAwareApiService {
   async get(endpoint: string): Promise<any> {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: "GET",
-      headers: this.getHeaders(),
+      headers: await this.getHeaders(),
     });
 
     if (!response.ok) {
@@ -170,7 +170,7 @@ export class PortalAwareApiService {
   async post(endpoint: string, data: any): Promise<any> {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: "POST",
-      headers: this.getHeaders(),
+      headers: await this.getHeaders(),
       body: JSON.stringify(data),
     });
 
@@ -184,7 +184,7 @@ export class PortalAwareApiService {
   async put(endpoint: string, data: any): Promise<any> {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: "PUT",
-      headers: this.getHeaders(),
+      headers: await this.getHeaders(),
       body: JSON.stringify(data),
     });
 
@@ -198,7 +198,7 @@ export class PortalAwareApiService {
   async delete(endpoint: string): Promise<any> {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: "DELETE",
-      headers: this.getHeaders(),
+      headers: await this.getHeaders(),
     });
 
     if (!response.ok) {
@@ -219,7 +219,7 @@ export class PortalAwareApiService {
     const response = await fetch(`${storeApiUrl}${endpoint}`, {
       ...options,
       headers: {
-        ...this.getHeaders(),
+        ...(await this.getHeaders()),
         ...options.headers,
       },
     });
@@ -241,7 +241,7 @@ export class PortalAwareApiService {
     const response = await fetch(`${authServiceUrl}${endpoint}`, {
       ...options,
       headers: {
-        ...this.getHeaders(),
+        ...(await this.getHeaders()),
         ...options.headers,
       },
     });

--- a/frontend/makrcave-frontend/lib/auth.ts
+++ b/frontend/makrcave-frontend/lib/auth.ts
@@ -39,7 +39,16 @@ function scheduleRefresh() {
 
 export const login = () => keycloak.login();
 export const logout = () => keycloak.logout();
-export const getToken = () => keycloak.token || '';
+export const getToken = async () => {
+  try {
+    await keycloak.updateToken(30);
+    return keycloak.token || '';
+  } catch (err) {
+    console.error('Token refresh failed', err);
+    login();
+    return '';
+  }
+};
 export const isAuthenticated = () => Boolean(keycloak.authenticated);
 export const getUser = () => keycloak.tokenParsed as any || null;
 

--- a/frontend/makrcave-frontend/services/apiService.ts
+++ b/frontend/makrcave-frontend/services/apiService.ts
@@ -247,7 +247,7 @@ async function apiCall<T>(
   });
 
   try {
-    const token = getToken();
+    const token = await getToken();
     const baseUrl = USE_MOCK_API ? MOCK_API_BASE_URL : API_BASE_URL;
 
     loggingService.debug('api', 'ApiService.apiCall', 'Making API call', {

--- a/frontend/makrcave-frontend/services/billingApi.ts
+++ b/frontend/makrcave-frontend/services/billingApi.ts
@@ -323,7 +323,7 @@ async function apiCall<T>(
 
   // Try real API call for local development
   try {
-    const token = getToken();
+    const token = await getToken();
 
     loggingService.debug('api', 'BillingApi.apiCall', 'Making real API call', {
       endpoint,

--- a/frontend/makrcave-frontend/services/fileUploadService.ts
+++ b/frontend/makrcave-frontend/services/fileUploadService.ts
@@ -60,7 +60,7 @@ class FileUploadService {
       formData.append('type', this.getFileType(file));
 
       // Get auth token
-      const token = getToken();
+      const token = await getToken();
 
       // Upload file
       const response = await fetch(`${this.baseUrl}/api/v1/upload`, {
@@ -285,7 +285,7 @@ class FileUploadService {
    */
   async deleteFile(filename: string): Promise<boolean> {
     try {
-      const token = getToken();
+      const token = await getToken();
 
       const response = await fetch(`${this.baseUrl}/api/v1/upload/${filename}`, {
         method: 'DELETE',
@@ -315,7 +315,7 @@ class FileUploadService {
    */
   async getUploads(): Promise<any[]> {
     try {
-      const token = getToken();
+      const token = await getToken();
 
       const response = await fetch(`${this.baseUrl}/api/v1/uploads`, {
         headers: {


### PR DESCRIPTION
## Summary
- Make getToken asynchronous in Gateway and MakrCave frontends, refreshing the Keycloak token and logging in when refresh fails
- Await refreshed token in API helpers and services to ensure authenticated requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b43712640832688cbadfdca7460ca