### PR TITLE
feat: secure websockets and persistent subscriptions

### DIFF
--- a/backends/event-service/requirements.txt
+++ b/backends/event-service/requirements.txt
@@ -4,3 +4,4 @@ websockets==12.0
 httpx==0.25.2
 pydantic==2.4.2
 python-multipart==0.0.6
+redis==5.0.1


### PR DESCRIPTION
## Summary
- enforce JWT validation for WebSocket and REST APIs
- persist event subscriptions in Redis
- add heartbeat and reconnection logic to client WebSocket hooks

## Testing
- `python -m py_compile backends/event-service/main.py makrcave-backend/routes/notifications.py makrcave-backend/routes/collaboration.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b45e721788326948663845fb3a0cd