### PR TITLE
Refactor store auth to use shared SSO utilities

### DIFF
--- a/makrx-store-frontend/src/app/auth/callback/page.tsx
+++ b/makrx-store-frontend/src/app/auth/callback/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { handleAuthCallback } from "@/lib/auth";
 import { Loader2, CheckCircle, XCircle } from "lucide-react";
+import { getAndClearRedirectUrl } from "../../../../../makrx-sso-utils.js";
 
 export default function AuthCallbackPage() {
   const router = useRouter();
@@ -33,14 +34,8 @@ export default function AuthCallbackPage() {
           setStatus('success');
           
           // Get stored redirect URL or default to home
-          const redirectUrl = sessionStorage.getItem('makrx_redirect_url') || 
-                            localStorage.getItem('makrx_pre_login_url') || 
-                            '/';
-          
-          // Clear stored URLs
-          sessionStorage.removeItem('makrx_redirect_url');
-          localStorage.removeItem('makrx_pre_login_url');
-          
+          const redirectUrl = getAndClearRedirectUrl() || '/';
+
           // Small delay for better UX
           setTimeout(() => {
             router.push(redirectUrl);


### PR DESCRIPTION
## Summary
- Replace custom login and callback logic with shared `makrx-sso-utils`
- Use `redirectToSSO` and `exchangeCodeForTokens` to enforce PKCE, nonce, and secure state
- Simplify auth callback page with `getAndClearRedirectUrl`

## Testing
- `npm test`
- `npm run typecheck`
- `npm run type-check` *(fails: Property 'featured' does not exist on type 'Product')*


------
https://chatgpt.com/codex/tasks/task_e_689b6a0ac33483268934c37ad5302dcd