### PR TITLE
refactor: externalize keycloak secrets

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-# .env is better suited for public variables, ie, variables that should not commited
-# For secret variables is better to use DevServerControl tool with set_env_variable: ["KEY", "SECRET"]
-
-# https://www.builder.io/c/docs/using-your-api-key
-VITE_PUBLIC_BUILDER_KEY=__BUILDER_PUBLIC_KEY__
-PING_MESSAGE="ping pong"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment configuration. Copy to `.env` and replace values.
+
+# https://www.builder.io/c/docs/using-your-api-key
+VITE_PUBLIC_BUILDER_KEY=__BUILDER_PUBLIC_KEY__
+PING_MESSAGE="ping pong"
+
+# Keycloak credentials
+KEYCLOAK_ADMIN_PASSWORD=change-me
+KEYCLOAK_CLIENT_SECRET=change-me

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist-ssr
 *.sw?
 
 .config/
-!.env
+.env

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -5,6 +5,7 @@ This guide covers deploying the MakrCave system to production servers with all n
 ## 📋 Prerequisites
 
 ### Server Requirements
+
 - **OS**: Ubuntu 20.04+ or RHEL 8+
 - **RAM**: Minimum 4GB (8GB recommended)
 - **CPU**: 2+ cores
@@ -12,12 +13,20 @@ This guide covers deploying the MakrCave system to production servers with all n
 - **Network**: Static IP with ports 80, 443, 8000 open
 
 ### Software Dependencies
+
 - **Docker**: 20.10+
 - **Docker Compose**: 2.0+
 - **Nginx**: 1.18+ (for reverse proxy)
 - **Node.js**: 18+ (for frontend builds)
 - **Python**: 3.9+ (for backend)
 - **PostgreSQL**: 13+ (recommended over SQLite for production)
+
+### Environment Variables
+
+Set the following secrets in your deployment environment or `.env` file:
+
+- `KEYCLOAK_ADMIN_PASSWORD` – password for the Keycloak admin user
+- `KEYCLOAK_CLIENT_SECRET` – client secret used by the auth service
 
 ## 🔧 Backend Deployment
 
@@ -234,7 +243,7 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
-    
+
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
@@ -268,7 +277,7 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/api.yourdomain.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/api.yourdomain.com/privkey.pem;
-    
+
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
@@ -279,12 +288,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
+
         # WebSocket support
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        
+
         # Timeouts
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
@@ -386,7 +395,7 @@ CMD ["nginx", "-g", "daemon off;"]
 Create `docker-compose.prod.yml`:
 
 ```yaml
-version: '3.8'
+version: "3.8"
 
 services:
   postgres:
@@ -563,6 +572,7 @@ sudo systemctl restart fail2ban
 ## 🚀 Deployment Checklist
 
 ### Pre-Deployment
+
 - [ ] Server meets minimum requirements
 - [ ] Domain DNS pointing to server
 - [ ] SSL certificates configured
@@ -571,6 +581,7 @@ sudo systemctl restart fail2ban
 - [ ] Firewall configured
 
 ### Backend Deployment
+
 - [ ] Python dependencies installed
 - [ ] Database migrations run successfully
 - [ ] Environment file configured
@@ -579,6 +590,7 @@ sudo systemctl restart fail2ban
 - [ ] Skill management system functional
 
 ### Frontend Deployment
+
 - [ ] Node.js dependencies installed
 - [ ] Production build created
 - [ ] Nginx configured correctly
@@ -587,6 +599,7 @@ sudo systemctl restart fail2ban
 - [ ] All pages loading correctly
 
 ### Post-Deployment
+
 - [ ] Health checks configured
 - [ ] Monitoring setup
 - [ ] Backup strategy implemented
@@ -599,6 +612,7 @@ sudo systemctl restart fail2ban
 ### Common Issues
 
 **Backend not starting:**
+
 ```bash
 # Check logs
 sudo journalctl -u makrcave-backend -n 50
@@ -611,6 +625,7 @@ sudo netstat -tulpn | grep :8000
 ```
 
 **Frontend not loading:**
+
 ```bash
 # Check Nginx status
 sudo systemctl status nginx
@@ -623,6 +638,7 @@ sudo tail -f /var/log/nginx/error.log
 ```
 
 **Database connection issues:**
+
 ```bash
 # Check PostgreSQL status
 sudo systemctl status postgresql

--- a/SECURITY_DEPLOYMENT_GUIDE.md
+++ b/SECURITY_DEPLOYMENT_GUIDE.md
@@ -21,7 +21,15 @@ This guide covers the security vulnerabilities that have been fixed and the depl
 
 ### 1. Environment Configuration
 
+#### Keycloak SSO
+
+```bash
+# Generate secure admin password
+export KEYCLOAK_ADMIN_PASSWORD=$(openssl rand -base64 32)
+```
+
 #### Auth Service
+
 ```bash
 # Copy and configure environment
 cp backends/auth-service/.env.example backends/auth-service/.env
@@ -34,6 +42,7 @@ export JWT_SECRET=$(openssl rand -base64 32)
 ```
 
 #### MakrCave Backend
+
 ```bash
 # Copy and configure environment
 cp makrcave-backend/.env.example makrcave-backend/.env
@@ -48,6 +57,7 @@ export DATABASE_URL="postgresql://makrcave_user:SECURE_PASSWORD@localhost:5432/m
 ```
 
 #### Event Service
+
 ```bash
 # Copy and configure environment
 cp backends/event-service/.env.example backends/event-service/.env
@@ -61,6 +71,7 @@ export API_KEY=$(openssl rand -base64 32)
 ### 2. Database Security Setup
 
 #### PostgreSQL Configuration
+
 ```sql
 -- Create dedicated users with minimal privileges
 CREATE USER makrcave_user WITH PASSWORD 'SECURE_RANDOM_PASSWORD';
@@ -79,6 +90,7 @@ GRANT CONNECT ON DATABASE makrx_events TO events_user;
 ```
 
 #### Database Encryption
+
 ```bash
 # Enable encryption at rest
 # PostgreSQL with pgcrypto extension
@@ -93,6 +105,7 @@ echo "ssl_key_file = '/etc/ssl/private/postgresql.key'" >> /etc/postgresql/13/ma
 ### 3. SSL/TLS Configuration
 
 #### Generate SSL Certificates
+
 ```bash
 # Option 1: Let's Encrypt (Recommended for production)
 sudo certbot certonly --nginx -d makrx.org -d makrcave.com -d makrx.store
@@ -102,21 +115,22 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 ```
 
 #### Nginx Configuration
+
 ```nginx
 # /etc/nginx/sites-available/makrx-ecosystem
 server {
     listen 443 ssl http2;
     server_name makrcave.com;
-    
+
     ssl_certificate /etc/letsencrypt/live/makrcave.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/makrcave.com/privkey.pem;
-    
+
     # Security headers
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
-    
+
     location /api/ {
         proxy_pass http://localhost:8000;
         proxy_set_header Host $host;
@@ -124,7 +138,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-    
+
     location / {
         proxy_pass http://localhost:3001;
         proxy_set_header Host $host;
@@ -143,6 +157,7 @@ server {
 ### 4. Firewall Configuration
 
 #### UFW (Ubuntu Firewall)
+
 ```bash
 # Reset and set defaults
 sudo ufw --force reset
@@ -169,6 +184,7 @@ sudo ufw enable
 ### 5. Application Security
 
 #### Install Dependencies
+
 ```bash
 # Install security dependencies
 cd makrcave-backend
@@ -182,6 +198,7 @@ pip install -r requirements.txt
 ```
 
 #### Start Services with Security
+
 ```bash
 # Auth Service
 cd backends/auth-service
@@ -199,6 +216,7 @@ uvicorn main:app --host 0.0.0.0 --port 8004 --ssl-keyfile=/path/to/key.pem --ssl
 ### 6. Monitoring and Logging
 
 #### Setup Log Rotation
+
 ```bash
 # /etc/logrotate.d/makrx-ecosystem
 /var/log/makrx/*.log {
@@ -216,6 +234,7 @@ uvicorn main:app --host 0.0.0.0 --port 8004 --ssl-keyfile=/path/to/key.pem --ssl
 ```
 
 #### Security Monitoring
+
 ```bash
 # Install fail2ban for intrusion detection
 sudo apt-get install fail2ban
@@ -244,6 +263,7 @@ sudo systemctl start fail2ban
 ### 7. Backup and Recovery
 
 #### Database Backups
+
 ```bash
 # Create backup script
 cat > /usr/local/bin/backup-makrx.sh << EOF
@@ -274,6 +294,7 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
 ## 🔧 Security Checklist
 
 ### Pre-Deployment
+
 - [ ] All environment variables configured with secure values
 - [ ] SSL certificates obtained and installed
 - [ ] Database users created with minimal privileges
@@ -282,6 +303,7 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
 - [ ] Monitoring tools installed
 
 ### Post-Deployment
+
 - [ ] All services running with SSL/TLS
 - [ ] Authentication working properly
 - [ ] Rate limiting active
@@ -291,6 +313,7 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
 - [ ] Monitoring alerts configured
 
 ### Ongoing Security
+
 - [ ] Regular security updates
 - [ ] Secret rotation schedule
 - [ ] Security log monitoring
@@ -303,13 +326,16 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
 ## 🚨 Emergency Response
 
 ### Security Incident Response
+
 1. **Immediate Actions**
+
    - Isolate affected systems
    - Change all potentially compromised secrets
    - Review access logs
    - Document the incident
 
 2. **Investigation**
+
    - Analyze attack vectors
    - Assess data exposure
    - Check for lateral movement
@@ -322,6 +348,7 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
    - Conduct post-incident review
 
 ### Emergency Contacts
+
 - **Security Team**: security@makrx.org
 - **Infrastructure Team**: infra@makrx.org
 - **On-call Engineer**: +1-XXX-XXX-XXXX
@@ -329,6 +356,7 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
 ## 📞 Support and Maintenance
 
 ### Regular Maintenance Tasks
+
 - **Daily**: Review security logs
 - **Weekly**: Check for security updates
 - **Monthly**: Rotate non-critical secrets
@@ -336,6 +364,7 @@ echo "0 2 * * * /usr/local/bin/backup-makrx.sh" | sudo crontab -
 - **Annually**: Penetration testing
 
 ### Security Tools Integration
+
 - **SIEM**: Splunk, ELK Stack, or similar
 - **Vulnerability Scanning**: Nessus, OpenVAS
 - **Intrusion Detection**: Suricata, Snort

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 networks:
   makrx-net:
@@ -43,7 +43,7 @@ services:
       KC_DB_PASSWORD: makrx-db-2024
       KC_DB_SCHEMA: keycloak
       KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: makrx-admin-2024
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     ports:
       - "8080:8080"
     depends_on:
@@ -65,7 +65,7 @@ services:
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: makrx
       KEYCLOAK_CLIENT_ID: auth-service
-      KEYCLOAK_CLIENT_SECRET: makrx-auth-service-secret-2024
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET}
     ports:
       - "8001:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- load Keycloak admin password and client secret from environment variables
- ignore .env and add .env.example with Keycloak placeholders
- document required Keycloak variables in deployment guides

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b7c7319c88326b5228a9547cefd1e